### PR TITLE
Add --min-severity flag for display filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and the project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v
 > Tags prior to **v0.4.0** were cut in the private repository and produced no
 > public artifacts; the first publicly released version is v0.4.0.
 
+## [Unreleased]
+
+### Added
+- **`--min-severity=<level>` display filter.** Hides findings below the
+  given severity in the rendered output (Cards, Markdown, `--copy`).
+  `--json` stays complete (machine contract) and `--fail-on` always
+  evaluates the full, unfiltered set — so CI gating is never weakened by
+  a display filter. Accepts `critical|high|medium|low|info|none`; an
+  invalid value errors before the provider call. Complements `--fail-on`
+  (which governs the exit code).
+
 ## [1.1.0] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ commitbrief cache prune [flags]            # bounded cleanup; defaults --keep-la
 ```
 
 Global flags: `--json`, `--markdown`, `--output <file>`, `--copy`,
-`--compact`, `--no-cache`, `--fail-on=<sev>`, `-f/--file` (repeatable),
+`--compact`, `--no-cache`, `--fail-on=<sev>`, `--min-severity=<sev>`
+(hide findings below this severity in the rendered output; `--json` and
+`--fail-on` still see the full set), `-f/--file` (repeatable),
 `-d/--dir` (repeatable), `--yes`, `--verbose`, `--quiet`, `--lang`,
 `--provider`, `--model`, `--cli <claude|gemini>` (shorthand for the
 CLI-tool-backed providers; mutually exclusive with `--json` /

--- a/internal/cli/minseverity.go
+++ b/internal/cli/minseverity.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CommitBrief/commitbrief/internal/render"
+)
+
+// parseMinSeverity maps the raw --min-severity flag to a display
+// threshold. "" / "none" disables the filter. The five canonical levels
+// enable it; anything else is an error so a typo surfaces instead of
+// silently showing everything. Mirrors parseFailOn's strictness.
+func parseMinSeverity(raw string) (threshold render.Severity, enabled bool, err error) {
+	switch s := render.Severity(strings.ToLower(strings.TrimSpace(raw))); s {
+	case "", "none":
+		return "", false, nil
+	case render.SeverityCritical, render.SeverityHigh, render.SeverityMedium, render.SeverityLow, render.SeverityInfo:
+		return s, true, nil
+	default:
+		return "", false, fmt.Errorf("invalid --min-severity value %q (expected: critical, high, medium, low, info, none)", raw)
+	}
+}
+
+// filterMinSeverity returns the findings at or above the --min-severity
+// threshold (lower severityRank = more severe, so "high" keeps critical
+// + high). It is a DISPLAY-only filter: when off, invalid, or given a
+// nil slice it returns the input unchanged. Callers validate the flag up
+// front (runReview) so the invalid case never reaches here on the happy
+// path, and --fail-on always evaluates the full, unfiltered set so the
+// CI gate is never weakened by a display filter.
+func filterMinSeverity(findings []render.Finding) []render.Finding {
+	threshold, enabled, err := parseMinSeverity(global.minSeverity)
+	if !enabled || err != nil || findings == nil {
+		return findings
+	}
+	tr := severityRank[threshold]
+	out := make([]render.Finding, 0, len(findings))
+	for _, f := range findings {
+		if rank, ok := severityRank[f.Severity]; ok && rank <= tr {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/internal/cli/minseverity_test.go
+++ b/internal/cli/minseverity_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CommitBrief/commitbrief/internal/render"
+)
+
+func TestParseMinSeverity(t *testing.T) {
+	for _, raw := range []string{"", "none", "NONE", "  "} {
+		if _, enabled, err := parseMinSeverity(raw); err != nil || enabled {
+			t.Errorf("parseMinSeverity(%q) = (enabled=%v, %v), want disabled/no-err", raw, enabled, err)
+		}
+	}
+	ok := map[string]render.Severity{
+		"critical": render.SeverityCritical,
+		"HIGH":     render.SeverityHigh,
+		" medium ": render.SeverityMedium,
+		"low":      render.SeverityLow,
+		"info":     render.SeverityInfo,
+	}
+	for raw, want := range ok {
+		got, enabled, err := parseMinSeverity(raw)
+		if err != nil || !enabled || got != want {
+			t.Errorf("parseMinSeverity(%q) = (%q, %v, %v), want (%q, true, nil)", raw, got, enabled, err, want)
+		}
+	}
+	for _, bad := range []string{"blocker", "warn", "any", "1"} {
+		if _, _, err := parseMinSeverity(bad); err == nil {
+			t.Errorf("parseMinSeverity(%q) should error", bad)
+		}
+	}
+}
+
+func sevFindings(sevs ...render.Severity) []render.Finding {
+	out := make([]render.Finding, 0, len(sevs))
+	for i, s := range sevs {
+		out = append(out, render.Finding{Severity: s, File: "f.go", Line: i + 1, Title: "t", Description: "d", Suggestion: "s"})
+	}
+	return out
+}
+
+func TestFilterMinSeverity(t *testing.T) {
+	prev := global.minSeverity
+	t.Cleanup(func() { global.minSeverity = prev })
+
+	all := sevFindings(render.SeverityCritical, render.SeverityHigh, render.SeverityMedium, render.SeverityLow, render.SeverityInfo)
+
+	// Disabled → unchanged.
+	global.minSeverity = ""
+	if got := filterMinSeverity(all); len(got) != 5 {
+		t.Errorf("disabled filter should keep all 5, got %d", len(got))
+	}
+
+	// high → critical + high only.
+	global.minSeverity = "high"
+	got := filterMinSeverity(all)
+	if len(got) != 2 || got[0].Severity != render.SeverityCritical || got[1].Severity != render.SeverityHigh {
+		t.Errorf("min=high should keep [critical, high], got %v", severitiesOf(got))
+	}
+
+	// info → keep all (lowest threshold).
+	global.minSeverity = "info"
+	if got := filterMinSeverity(all); len(got) != 5 {
+		t.Errorf("min=info should keep all 5, got %d", len(got))
+	}
+
+	// critical → only critical.
+	global.minSeverity = "critical"
+	if got := filterMinSeverity(sevFindings(render.SeverityHigh, render.SeverityCritical, render.SeverityLow)); len(got) != 1 || got[0].Severity != render.SeverityCritical {
+		t.Errorf("min=critical should keep only critical, got %v", severitiesOf(got))
+	}
+
+	// nil → nil (degrade case).
+	if got := filterMinSeverity(nil); got != nil {
+		t.Errorf("nil findings should stay nil, got %v", got)
+	}
+}
+
+func severitiesOf(fs []render.Finding) []render.Severity {
+	out := make([]render.Severity, len(fs))
+	for i, f := range fs {
+		out[i] = f.Severity
+	}
+	return out
+}
+
+// The mock provider returns a single "info" finding titled "mock review
+// output". --min-severity=high should hide it from the rendered output.
+func TestMinSeverityHidesBelowThresholdInRender(t *testing.T) {
+	e := newCLIEnv(t)
+	if err := e.run("--staged", "--min-severity=high"); err != nil {
+		t.Fatalf("review: %v", err)
+	}
+	if strings.Contains(e.out.String(), "mock review output") {
+		t.Errorf("info finding should be hidden by --min-severity=high; got:\n%s", e.out.String())
+	}
+}
+
+// --fail-on must evaluate the FULL set: --min-severity=high hides the
+// info finding from display, but --fail-on=info still trips the gate.
+func TestMinSeverityDoesNotWeakenFailOn(t *testing.T) {
+	e := newCLIEnv(t)
+	err := e.run("--staged", "--min-severity=high", "--fail-on=info")
+	if err == nil {
+		t.Fatal("--fail-on=info must still fire on the hidden info finding (full set), but exit was 0")
+	}
+}
+
+// --json is the machine contract and stays complete regardless of the
+// display filter.
+func TestMinSeverityDoesNotFilterJSON(t *testing.T) {
+	e := newCLIEnv(t)
+	if err := e.run("--staged", "--min-severity=high", "--json"); err != nil {
+		t.Fatalf("review --json: %v", err)
+	}
+	if !strings.Contains(e.out.String(), "mock review output") {
+		t.Errorf("--json must keep the full finding set despite --min-severity; got:\n%s", e.out.String())
+	}
+}
+
+// A typo fails fast (before the provider call) rather than silently
+// disabling the filter.
+func TestMinSeverityInvalidValueErrors(t *testing.T) {
+	e := newCLIEnv(t)
+	if err := e.run("--staged", "--min-severity=hgih"); err == nil {
+		t.Fatal("invalid --min-severity should error")
+	}
+}

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -52,6 +52,12 @@ func runReview(cmd *cobra.Command, scope reviewScopeFlags, diffArgs []string) er
 		return err
 	}
 
+	// Validate --min-severity up front so a typo fails fast instead of
+	// silently showing every finding after a paid provider round-trip.
+	if _, _, err := parseMinSeverity(global.minSeverity); err != nil {
+		return err
+	}
+
 	// Load rules + output template up front so any "using built-in"
 	// infof emissions land BEFORE the progress UI starts animating —
 	// otherwise they would interleave with the spinner's cursor-up
@@ -441,6 +447,9 @@ func handleCopyFlag(cmd *cobra.Command, app *appContext, findings []render.Findi
 	if !global.copy {
 		return
 	}
+	// Copy honours --min-severity too — it's a display/share surface, so
+	// the user only shares what they chose to see.
+	findings = filterMinSeverity(findings)
 	w := cmd.ErrOrStderr()
 	hint := func(key string, args ...any) {
 		if global.quiet {
@@ -580,10 +589,15 @@ func renderResult(cmd *cobra.Command, content, outputTemplate string, findings [
 	}
 	defer closer()
 
-	// JSON is machine output: emit it exactly, with no trailing blank line.
+	// JSON is machine output: emit it exactly (full, unfiltered) with no
+	// trailing blank line. --min-severity is a display-only filter and
+	// must not touch the machine contract.
 	if global.json {
 		return render.JSON(w, payload)
 	}
+
+	// Human render paths honour --min-severity (Cards / Markdown).
+	payload.Findings = filterMinSeverity(payload.Findings)
 
 	var rerr error
 	switch {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ type globalFlags struct {
 	noCostCheck  bool
 	copy         bool
 	failOn       string
+	minSeverity  string
 	lang         string
 	provider     string
 	model        string
@@ -87,6 +88,7 @@ func newRootCmd() *cobra.Command {
 	flags.BoolVar(&global.noCostCheck, "no-cost-check", false, "skip the pre-send cost estimate prompt")
 	flags.BoolVar(&global.copy, "copy", false, "copy findings (severity, path, title, description) to the system clipboard via OSC 52 + native tool")
 	flags.StringVar(&global.failOn, "fail-on", "", "exit 1 if any finding meets/exceeds severity (critical|high|medium|low|info|any|none)")
+	flags.StringVar(&global.minSeverity, "min-severity", "", "hide findings below this severity in the rendered output (critical|high|medium|low|info); --json and --fail-on still see the full set")
 	flags.StringVar(&global.lang, "lang", "", "override output language (e.g. tr, en)")
 	flags.StringVar(&global.provider, "provider", "", "override configured provider")
 	flags.StringVar(&global.model, "model", "", "override configured model")


### PR DESCRIPTION
<!--
  Thanks for opening a pull request.

  Please fill in the sections below. Sections you do not need can be removed,
  but please keep at least Summary and Test plan.

  Tip: Conventional Commit style in the PR title (e.g. "feat(cli): add
  --no-history flag") helps with changelog generation.
-->

## Summary

<!-- One to three sentences describing what this PR does and why. -->

## Related issues

<!-- e.g. Fixes #123, Refs #456. Remove this section if not applicable. -->

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (behavior or API)
- [ ] Documentation only
- [ ] Refactor / cleanup (no behavior change)
- [ ] Build / release / CI

## Test plan

<!--
  How did you verify this change works? What did you check that it does not
  break? Be specific: commands run, scenarios tested, edge cases considered.
-->

- [ ] `make lint test` passes locally
- [ ] Added or updated tests for the new behavior
- [ ] Manually verified the affected commands in a real repo

## Notes for reviewers

<!--
  Anything reviewers should pay extra attention to? Trade-offs you considered?
  Decisions you would like a second opinion on? Remove if not applicable.
-->

## Checklist

- [ ] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] My contribution is licensed under GPL-3.0-or-later (inbound = outbound).
- [ ] User-facing strings use `internal/i18n` (no hard-coded text).
- [ ] If this changes user-visible behavior, the README / man page / `commitbrief list` output has been updated accordingly.
