### PR TITLE
Fix base repo slug derivation from PR URL, update related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and the project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v
 > Tags prior to **v0.4.0** were cut in the private repository and produced no
 > public artifacts; the first publicly released version is v0.4.0.
 
+## [Unreleased]
+
+### Fixed
+- **`commitbrief remote pr` no longer requests a non-existent `gh` JSON
+  field.** `gh pr view --json` has no `baseRepository` field, so the PR
+  fetch failed with `Unknown JSON field: "baseRepository"` against every
+  real `gh` version. The base repository slug used for posting inline
+  comments is now derived from the PR's `url` field (which always points
+  at the base repo, including cross-fork PRs).
+
 ## [1.1.0] - 2026-05-28
 
 ### Added

--- a/internal/cli/remote_pr.go
+++ b/internal/cli/remote_pr.go
@@ -220,7 +220,7 @@ func submitPRReview(ctx context.Context, runner remote.Runner, prID string, f re
 	if len(postable) > 0 {
 		infof("%s", cat.T("remote.posting_comments", len(postable)))
 	}
-	slug := meta.BaseRepository.Slug()
+	slug := meta.BaseSlug()
 	posted, failed := 0, 0
 	for _, fnd := range postable {
 		if fnd.Line <= 0 {

--- a/internal/cli/remote_pr_test.go
+++ b/internal/cli/remote_pr_test.go
@@ -216,7 +216,7 @@ func jsonField(args []string) string {
 
 func prMetaJSON(author, oid string) string {
 	return `{"number":42,"author":{"login":"` + author + `"},` +
-		`"baseRepository":{"name":"web","owner":{"login":"CommitBrief"}},` +
+		`"url":"https://github.com/CommitBrief/web/pull/42",` +
 		`"headRepository":{"name":"web","owner":{"login":"forker"}},` +
 		`"commits":[{"oid":"` + oid + `"}]}`
 }

--- a/internal/remote/pr.go
+++ b/internal/remote/pr.go
@@ -13,7 +13,7 @@ type owner struct {
 	Login string `json:"login"`
 }
 
-// repoRef mirrors gh's baseRepository / headRepository shape.
+// repoRef mirrors gh's headRepository shape.
 type repoRef struct {
 	Name  string `json:"name"`
 	Owner owner  `json:"owner"`
@@ -27,12 +27,32 @@ type commit struct {
 }
 
 // PRMeta is the subset of `gh pr view --json ...` that remote pr consumes.
+//
+// Note: gh does not expose a baseRepository field on PRs — the base repo is
+// derived from the PR URL (which always points at the base repo) via BaseSlug.
 type PRMeta struct {
 	Number         int      `json:"number"`
 	Author         owner    `json:"author"`
-	BaseRepository repoRef  `json:"baseRepository"`
+	URL            string   `json:"url"`
 	HeadRepository repoRef  `json:"headRepository"`
 	Commits        []commit `json:"commits"`
+}
+
+// BaseSlug returns the base repository as "owner/name", parsed from the PR
+// URL (https://<host>/<owner>/<repo>/pull/<n>). A PR's web URL always lives on
+// the base repo, so this is correct even for cross-fork PRs. Returns "" if the
+// URL is malformed.
+func (m PRMeta) BaseSlug() string {
+	u := m.URL
+	if i := strings.Index(u, "://"); i >= 0 {
+		u = u[i+3:]
+	}
+	// parts: [host, owner, repo, "pull", n]
+	parts := strings.Split(strings.TrimPrefix(u, "/"), "/")
+	if len(parts) >= 3 {
+		return parts[1] + "/" + parts[2]
+	}
+	return ""
 }
 
 // LastOID returns the head commit OID, or "" when the PR has no commits.
@@ -46,7 +66,7 @@ func (m PRMeta) LastOID() string {
 // AuthorLogin returns the PR author's GitHub login.
 func (m PRMeta) AuthorLogin() string { return m.Author.Login }
 
-const prViewFields = "number,author,baseRepository,headRepository,commits"
+const prViewFields = "number,author,url,headRepository,commits"
 
 // repoArgs appends `--repo owner/repo` when repo is non-empty.
 func repoArgs(repo string, args ...string) []string {
@@ -56,7 +76,7 @@ func repoArgs(repo string, args ...string) []string {
 	return args
 }
 
-// FetchPRMeta runs `gh pr view <id> --json number,author,baseRepository,headRepository,commits`.
+// FetchPRMeta runs `gh pr view <id> --json number,author,url,headRepository,commits`.
 func FetchPRMeta(ctx context.Context, r Runner, id, repo string) (PRMeta, error) {
 	var m PRMeta
 	err := runJSON(ctx, r, &m, repoArgs(repo, "pr", "view", id, "--json", prViewFields)...)

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -150,7 +150,7 @@ func TestFetchPRMetaUnmarshal(t *testing.T) {
 	canned := []byte(`{
 		"number": 42,
 		"author": {"login": "contributor"},
-		"baseRepository": {"name": "web", "owner": {"login": "CommitBrief"}},
+		"url": "https://github.com/CommitBrief/web/pull/42",
 		"headRepository": {"name": "web", "owner": {"login": "fork-user"}},
 		"commits": [{"oid": "aaa"}, {"oid": "bbb"}]
 	}`)
@@ -165,11 +165,28 @@ func TestFetchPRMetaUnmarshal(t *testing.T) {
 	if m.AuthorLogin() != "contributor" {
 		t.Errorf("author = %q, want contributor", m.AuthorLogin())
 	}
-	if got := m.BaseRepository.Slug(); got != "CommitBrief/web" {
+	if got := m.BaseSlug(); got != "CommitBrief/web" {
 		t.Errorf("base slug = %q, want CommitBrief/web", got)
 	}
 	if got := m.LastOID(); got != "bbb" {
 		t.Errorf("last oid = %q, want bbb", got)
+	}
+}
+
+func TestBaseSlug(t *testing.T) {
+	cases := []struct {
+		url, want string
+	}{
+		{"https://github.com/CommitBrief/web/pull/42", "CommitBrief/web"},
+		{"https://github.com/greenglobaltr/BulutApi/pull/1652", "greenglobaltr/BulutApi"},
+		{"https://ghe.example.com/org/repo/pull/3", "org/repo"},
+		{"", ""},
+		{"not-a-url", ""},
+	}
+	for _, c := range cases {
+		if got := (PRMeta{URL: c.url}).BaseSlug(); got != c.want {
+			t.Errorf("BaseSlug(%q) = %q, want %q", c.url, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request.

  Please fill in the sections below. Sections you do not need can be removed,
  but please keep at least Summary and Test plan.

  Tip: Conventional Commit style in the PR title (e.g. "feat(cli): add
  --no-history flag") helps with changelog generation.
-->

## Summary

<!-- One to three sentences describing what this PR does and why. -->

## Related issues

<!-- e.g. Fixes #123, Refs #456. Remove this section if not applicable. -->

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (behavior or API)
- [ ] Documentation only
- [ ] Refactor / cleanup (no behavior change)
- [ ] Build / release / CI

## Test plan

<!--
  How did you verify this change works? What did you check that it does not
  break? Be specific: commands run, scenarios tested, edge cases considered.
-->

- [ ] `make lint test` passes locally
- [ ] Added or updated tests for the new behavior
- [ ] Manually verified the affected commands in a real repo

## Notes for reviewers

<!--
  Anything reviewers should pay extra attention to? Trade-offs you considered?
  Decisions you would like a second opinion on? Remove if not applicable.
-->

## Checklist

- [ ] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] My contribution is licensed under GPL-3.0-or-later (inbound = outbound).
- [ ] User-facing strings use `internal/i18n` (no hard-coded text).
- [ ] If this changes user-visible behavior, the README / man page / `commitbrief list` output has been updated accordingly.
