### PR TITLE
Update version flag handling and logo printing logic in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and the project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v
 ## [Unreleased]
 
 ### Changed
+- **`--version` no longer prints the splash logo.** `commitbrief --version`
+  now emits only the single `commitbrief vX.Y.Z (commit <sha>, built <iso-ts>)`
+  line, so the output is trivially parseable by scripts. The branding logo is
+  unchanged for `--help` and every other invocation; the version line itself
+  is identical to before.
 - **Interactive Yes/No confirmation prompts.** On a TTY, every confirmation
   prompt — the pre-send `.commitbrief/**` guard, the secret-scan warning, the
   cost preflight, the token/context-window preflight, `cache clear`, and the

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -141,6 +141,22 @@ func newRootCmd() *cobra.Command {
 	return cmd
 }
 
+// versionFlagRequested reports whether args contain the --version flag
+// before a "--" terminator. Cobra owns the flag itself; Execute only
+// peeks so it can suppress the branding logo for `commitbrief --version`
+// and keep that invocation's output a single parseable line.
+func versionFlagRequested(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if a == "--version" {
+			return true
+		}
+	}
+	return false
+}
+
 // Execute is the package entry point used by cmd/commitbrief/main.go.
 func Execute() {
 	// UC-18: on Windows the VT100 escape mode needs to be opted into
@@ -160,7 +176,13 @@ func Execute() {
 	// CI logs don't fill up with raw 24-bit color escapes. The version
 	// string is the resolved value (ldflags-injected at release time,
 	// debug.BuildInfo for `go install`, or "dev" for ad-hoc builds).
-	if ui.ColorEnabled(os.Stderr, ui.ColorAuto) {
+	//
+	// Suppressed for `--version`: that flag is meant to emit a single
+	// machine-parseable line — cobra prints version.Info() to stdout —
+	// so the logo (which lands on stderr above it on a TTY) must not
+	// appear. We peek os.Args because the logo prints before cobra
+	// parses flags; --help and every other invocation keep the logo.
+	if ui.ColorEnabled(os.Stderr, ui.ColorAuto) && !versionFlagRequested(os.Args[1:]) {
 		logo.Print(os.Stderr, version.Version)
 	}
 

--- a/internal/cli/version_logo_test.go
+++ b/internal/cli/version_logo_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cli
+
+import "testing"
+
+// versionFlagRequested gates whether Execute prints the branding logo:
+// `commitbrief --version` must emit a single parseable line (no logo),
+// while every other invocation — including --help — keeps the logo.
+func TestVersionFlagRequested(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"bare", nil, false},
+		{"version only", []string{"--version"}, true},
+		{"version after subcommand", []string{"diff", "--version"}, true},
+		{"version with other flags", []string{"--json", "--version"}, true},
+		{"help is not version", []string{"--help"}, false},
+		{"staged review", []string{"--staged"}, false},
+		// A "--" terminator hands the rest to positional args (e.g. a git
+		// pathspec for `diff`), so a later --version is not our flag.
+		{"version after terminator", []string{"diff", "--", "--version"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := versionFlagRequested(tc.args); got != tc.want {
+				t.Errorf("versionFlagRequested(%q) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thanks for opening a pull request.

  Please fill in the sections below. Sections you do not need can be removed,
  but please keep at least Summary and Test plan.

  Tip: Conventional Commit style in the PR title (e.g. "feat(cli): add
  --no-history flag") helps with changelog generation.
-->

## Summary

<!-- One to three sentences describing what this PR does and why. -->

## Related issues

<!-- e.g. Fixes #123, Refs #456. Remove this section if not applicable. -->

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (behavior or API)
- [ ] Documentation only
- [ ] Refactor / cleanup (no behavior change)
- [ ] Build / release / CI

## Test plan

<!--
  How did you verify this change works? What did you check that it does not
  break? Be specific: commands run, scenarios tested, edge cases considered.
-->

- [ ] `make lint test` passes locally
- [ ] Added or updated tests for the new behavior
- [ ] Manually verified the affected commands in a real repo

## Notes for reviewers

<!--
  Anything reviewers should pay extra attention to? Trade-offs you considered?
  Decisions you would like a second opinion on? Remove if not applicable.
-->

## Checklist

- [ ] I have read the [Contributing guide](../CONTRIBUTING.md).
- [ ] My contribution is licensed under GPL-3.0-or-later (inbound = outbound).
- [ ] User-facing strings use `internal/i18n` (no hard-coded text).
- [ ] If this changes user-visible behavior, the README / man page / `commitbrief list` output has been updated accordingly.
